### PR TITLE
Prevent version change with boolean

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,3 +12,4 @@
 #go_tarball_checksum: "sha256:43ad621c9b014cde8db17393dc108378d37bc853aa351a6c74bf6432c1bbd182"
 go_version_target: "go version go{{ go_version }} linux/amd64"
 set_go_path: true
+allow_version_change: True

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,14 +37,16 @@
   file:
     path: /usr/local/go
     state: absent
-  when: current_go_version|failed or current_go_version.stdout != go_version_target
+  when: current_go_version|failed or
+    (current_go_version.stdout != go_version_target and allow_version_change | bool)
 
 - name: Extract the Go tarball if Go is not yet installed or not the desired version
   unarchive:
     src: /usr/local/src/{{ go_tarball }}
     dest: /usr/local
     copy: no
-  when: current_go_version|failed or current_go_version.stdout != go_version_target
+  when: current_go_version|failed or
+    (current_go_version.stdout != go_version_target and allow_version_change | bool)
 
 - name: Add the Go bin directory to the PATH environment variable for all users
   copy:


### PR DESCRIPTION
This commit makes possible to disable an automatic version change by
setting `allow_version_change` to `False`.

Signed-off-by: Jean-Philippe Evrard jean-philippe@evrard.me
